### PR TITLE
pagseguro: incluir flag PAGSEGURO_PRODUCTION para controler sandbox. 

### DIFF
--- a/config/initializers/pagseguro.rb
+++ b/config/initializers/pagseguro.rb
@@ -1,3 +1,6 @@
 raise "Variável de ambiente PAGSEGURO_EMAIL não informada" if ENV["PAGSEGURO_EMAIL"].nil?
 raise "Variável de ambiente PAGSEGURO_TOKEN não informada" if ENV["PAGSEGURO_TOKEN"].nil?
-PagSeguro.environment = :sandbox
+raise "Variável de ambiente PAGSEGURO_PRODUCTION não informada" if ENV["PAGSEGURO_PRODUCTION"].nil?
+
+puts "Usando sandbox no PagSeguro" if ENV["PAGSEGURO_PRODUCTION"] == "false"
+PagSeguro.environment = :sandbox if ENV["PAGSEGURO_PRODUCTION"] == "false"


### PR DESCRIPTION
Fix #40 

Já setei a variável de ambiente PAGSEGURO_PRODUCTION no Heroku para os dois ambientes (dev e prod).
